### PR TITLE
Update challenge answer form style

### DIFF
--- a/src/server/views/pages/challenge.ejs
+++ b/src/server/views/pages/challenge.ejs
@@ -55,9 +55,14 @@ function goBack() {
     <%- props.html %>
     <% if (!props.challenge.hidesubmit) { %>
       <form autocomplete="off" method="post" id="challenge_form">
-        <input id="challenge_answer" type="text" name="answer" style="height:32px">
-        <input type="submit" id="challenge_submit" value="<%= t('go') %>" style="height:32px;line-height:1;vertical-align:bottom;">
-      </form>
+        <div class="form-group">
+          <label>
+            <input id="challenge_answer" class="form-control" type="text" name="answer" style="height: 32px">
+          </label>
+          <span style="display:inline-block;width:3px;"></span>
+          <button type="submit" id="challenge_submit" class="btn btn-success" style="height: 32px; line-height: 1; background-color: #008563; border-color: #007054; margin-top: -1px"><%= t('go') %></button>
+  </div>
+</form>
     <% } %>
   <% } %>
 

--- a/src/server/views/pages/challenge.ejs
+++ b/src/server/views/pages/challenge.ejs
@@ -18,7 +18,7 @@ function goBack() {
     <% if (props.correct !== true) { %>
       <a href="<%=prefix%>/map" <%- App.config.historyBack ? 'onclick="goBack()"' : ''%>><%= t('back') %></a><span style="display: inline-block; margin-left:8px; margin-right: 8px; color: #313131">•</span>
     <% } %>
-    <span style="color: gray" title="<%= props.solvedBy == 1 ? t('solvedBy_one', {count: props.solvedBy}) : t('solvedBy_other', {count: props.solvedBy}) %>, <% if (props.lastSolved !== null) { %><%=t('lastSolved', {ago: App.moment(props.lastSolved).locale(locale).fromNow(), name: props.lastSolvedUserName})%><%}%>">
+    <span style="color: gray" title="<%= props.solvedBy == 1 ? t('solvedBy_one', {count: props.solvedBy}) : t('solvedBy_other', {count: props.solvedBy}) %><% if (props.lastSolved !== null) { %><%= ', ' + t('lastSolved', {ago: App.moment(props.lastSolved).locale(locale).fromNow(), name: props.lastSolvedUserName})%><%}%>">
       <%= props.ratio %>
     </span>
     <% if (props.challenge.date) { %><span style="display: inline-block; margin-left:8px; margin-right: 8px; color: #313131">•</span>


### PR DESCRIPTION
This PR updates the style of the challenge answer input:

From:
<img width="209" height="53" alt="Screenshot 2025-09-02 at 19 59 35" src="https://github.com/user-attachments/assets/511e3fda-ef46-498a-907d-395882c1f0f9" />
To:
<img width="291" height="65" alt="Screenshot 2025-09-02 at 19 59 49" src="https://github.com/user-attachments/assets/d718505f-cd79-45de-bb33-58bdc577da0e" />

- The space between the two elements can be adjusted if you want

- The sizes of the screenshots vary, but both fields are 32 px high

I just used the styles and class names from the login input form.

---

I also fixed a little bug with the display of how many persons solved a challenge: If no one has solved a challenge yet, the title of the text says `insgesamt von 0 Personen, `. I put the `, ` inside the if clause so it's not shown when the number is 0.

---

I also tried to style the language picker, but plain HTML and CSS have a few limitations and the dropdown icon would disappear if I changed the style. You would have to use a custom icon or another dropdown component.

<img width="216" height="43" alt="Screenshot 2025-09-02 at 20 08 15" src="https://github.com/user-attachments/assets/6e52f172-cad2-4366-a7e1-1e53f2bd6124" />

(This one is the ▼ Unicode sign but it's also shown in the opened option list)

If you have any additional feedback, please let me know!